### PR TITLE
DragonRuby wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/wildfiler/drtiled?label=version&style=plastic)
 
-This is a library for loading Tiled map files in [Dragon Ruby GTK](https://dragonruby.org/toolkit/game).
+This is a library for loading Tiled map files in [DragonRuby Game Toolkit](https://dragonruby.org/toolkit/game).
 
 It supports TMX format directly allowing skip exporting to json or csv files step.
 


### PR DESCRIPTION
Dragon Ruby -> DragonRuby:
It's one word and will make it easier to google w/o the space in between Dragon and Ruby.

GTK -> Game Toolkit:
This will avoid people asking if DragonRuby is in any way related to Linux's GTK. You'll get that a lot of you use the GTK abbreviation.