### PR TITLE
Fix to handling .. in paths

### DIFF
--- a/lib/tiled/utils.rb
+++ b/lib/tiled/utils.rb
@@ -3,7 +3,7 @@ module Tiled
     module_function def relative_to_absolute(path)
       absolute_path = path.split(File::SEPARATOR).inject([]) do |memo, element|
         if element == ".."
-          memo.shift
+          memo.pop
         else
           memo.push(element)
         end


### PR DESCRIPTION
`Tiled::Utils.relative_to_absolute` doesn't handle relative files where the `..` element(s) are deeper in the path.

For example; `mygame/data/../sprites/spritesheet.png` currently gets resolved to `data/sprites/spritesheet.png` - this is because finding a `..` element calls `shift` (removing the front element of the path) instead of `pop` (to remove the latest).

With this fix, it correctly resolves to `mygame/sprites/spritesheet.png`
