### PR TITLE
Make Y-axis for `Layer#tile_at` reversible

### DIFF
--- a/lib/tiled/layer.rb
+++ b/lib/tiled/layer.rb
@@ -42,10 +42,10 @@ module Tiled
       end
     end
 
-    # Get tile by x, y coordinates
+    # Get tile by x, y coordinates (0, 0 is based on tile render order)
     # @return [Tiled::Tile, nil] tile at x, y coordinate on this layer or `nil`
     def tile_at(x, y)
-      tiles[y][x]
+      tiles[render_order == RIGHT_DOWN ? y : map.attributes.height.to_i - 1 - y][x]
     end
 
     # Method to get array of visible and renderable sprites from layer.


### PR DESCRIPTION
It will go off the tile render order set for the map. The right-down behavior is inconsistent with DragonRuby's pixel coordinates and makes calculations involving tile positions more complicated.