### PR TITLE
Add object layer support

### DIFF
--- a/lib/tiled/object_layer.rb
+++ b/lib/tiled/object_layer.rb
@@ -79,51 +79,7 @@ module Tiled
           }
         when :polygon
           # Get the starting point of the polygon
-          x_offset = object.x + object.points[0].x - 1
-          y_offset = object.y + object.points[0].y
-
-          # Find the top and bottom of the polygon
-          y_values = object.points.map { |p| p.y.to_i }
-          min_y, max_y = y_values.min, y_values.max
-
-          # Similar to the circle, this is drawn as a bunch of horizontal lines
-          (max_y - min_y).times do |y|
-            # We need to get the intersections where a horizontal line
-            # across the screen crosses the edges of the polygon
-            intersections = []
-
-            y += min_y
-
-            object.points.each_with_index do |point, index|
-              next_point = object.points[(index + 1) % object.points.length]
-
-              # We're iterating over each point to find the lines where the
-              # "scan line" that we're drawing intersects. This will only hit
-              # twice, once on each side
-              if (point.y <= y && next_point.y > y) || (next_point.y <= y && point.y > y)
-                if point.y == next_point.y
-                  # The edge is horizontal, so the intersection is just the
-                  # X-coordinate of the point
-                  intersections << x_offset + point.x
-                else
-                  # Find the X-coordinate where the edge intersects the
-                  # row using the equation of the line
-                  intersections << x_offset +
-                    ((y - point.y) * (next_point.x - point.x) /
-                     (next_point.y - point.y)) + point.x
-                end
-              end
-            end
-
-            screen_y = y_offset + y
-
-            outputs_layer << {
-              x: intersections[0], y: screen_y,
-              x2: intersections[1], y2: screen_y,
-              **color.to_h,
-              a: (color.a * 0.7).to_i
-            }
-          end
+          offset = [object.x + object.points[0].x, object.y + object.points[0].y]
 
           # Draw the outline connecting each point
           object.points.each_with_index do |point, index|

--- a/lib/tiled/object_layer.rb
+++ b/lib/tiled/object_layer.rb
@@ -75,7 +75,7 @@ module Tiled
             path: :ellipse,
             source_x: 0, source_y: 0,
             source_w: diameter, source_h: diameter,
-            a: 100, **color.to_h
+            **color.to_h, a: color.a * 0.7
           }
         when :polygon
           # Get the starting point of the polygon

--- a/lib/tiled/object_layer.rb
+++ b/lib/tiled/object_layer.rb
@@ -49,7 +49,7 @@ module Tiled
           length = Math::sqrt(radius * radius - height * height)
           args.render_target(:ellipse).lines << {
             x: i, y: radius - length, x2: i, y2: radius + length,
-            **color.to_h
+            r: 255, g: 255, b: 255
           }
         end
 
@@ -75,7 +75,7 @@ module Tiled
             path: :ellipse,
             source_x: 0, source_y: 0,
             source_w: diameter, source_h: diameter,
-            a: 255
+            a: 100, **color.to_h
           }
         when :polygon
           # Get the starting point of the polygon
@@ -86,8 +86,8 @@ module Tiled
             next_point = object.points[(index + 1) % object.points.length]
 
             outputs_layer << {
-              x: x_offset + point.x, y: y_offset + point.y,
-              x2: x_offset + next_point.x, y2: y_offset + next_point.y,
+              x: offset.x + point.x, y: offset.y + point.y,
+              x2: offset.x + next_point.x, y2: offset.y + next_point.y,
               **color.to_h
             }
           end


### PR DESCRIPTION
This commit adds an API for Tiled's object layers. It adds 2 classes:

 * `TiledObject` - Represents a single object
 * `ObjectLayer` - A layer of one or more `TiledObject`s

refs #14