### PR TITLE
Fix `id` attribute accessor

### DIFF
--- a/lib/tiled/with_attributes.rb
+++ b/lib/tiled/with_attributes.rb
@@ -42,6 +42,15 @@ module Tiled
       attributes.respond_to?(name) || super
     end
 
+    # Overrides Kernel#id if there is an :id attribute
+    def id
+      if attributes.respond_to?(:id)
+        attributes.send :id
+      else
+        super
+      end
+    end
+
     def self.included(base)
       base.extend(ClassMethods)
     end


### PR DESCRIPTION
Calling `#id` on objects using this module wasn't tripping the `method_missing` because it was hitting `Kernel#id`, which in DragonRuby seems to return `nil` for most objects. This commit overrides `Kernel#id` if there is an `id` attribute present.