### PR TITLE
Render fill for polygons

### DIFF
--- a/lib/tiled/object_layer.rb
+++ b/lib/tiled/object_layer.rb
@@ -79,19 +79,96 @@ module Tiled
             **color.to_h, a: color.a * 0.7
           }
         when :polygon
-          # Get the starting point of the polygon
-          offset = [object.x + object.points[0].x, object.y + object.points[0].y]
+          target = :"polygon#{object.id}"
 
-          # Draw the outline connecting each point
-          object.points.each_with_index do |point, index|
-            next_point = object.points[(index + 1) % object.points.length]
+          # Find the top and bottom of the polygon
+          y_values = object.points.map { |p| p.y }
+          min_y, max_y = y_values.min, y_values.max
+          # Find the sides
+          x_values = object.points.map { |p| p.x }
+          min_x, max_x = x_values.min, x_values.max
 
-            outputs_layer << {
-              x: offset.x + point.x, y: offset.y + point.y,
-              x2: offset.x + next_point.x, y2: offset.y + next_point.y,
-              **color.to_h
-            }
+          args.state.polygon_cached ||= {}
+          unless args.state.polygon_cached[target]
+            # Get the starting point of the polygon
+            offset = [object.points[0].x * 2 - min_x + 1, object.points[0].y * 2 - min_y + 1]
+
+            # Similar to the circle, this is drawn as a bunch of horizontal lines
+            (max_y - min_y).to_i.times do |y|
+              # We need to get the intersections where a horizontal line
+              # across the screen crosses the edges of the polygon
+              intersections = []
+
+              y += min_y
+
+              object.points.each_with_index do |point, index|
+                next_point = object.points[(index + 1) % object.points.length]
+
+                # We're iterating over each line of the polygon. This if statement
+                # will hit on each line that intersects the line that we're drawing
+                if (point.y <= y && next_point.y > y) || (next_point.y <= y && point.y > y)
+                  if point.y == next_point.y
+                    # The edge is horizontal, so the intersection is just the
+                    # X-coordinate of the point
+                    intersections << offset.x + point.x
+                  else
+                    # Find the X-coordinate where the edge intersects the
+                    # row using the equation of the line
+                    intersections << offset.x +
+                      ((y - point.y) * (next_point.x - point.x) /
+                       (next_point.y - point.y)) + point.x
+                  end
+                end
+              end
+
+              # Y-coordinate on the sprite that this line is being drawn
+              sprite_y = offset.y + y
+
+              # `intersections` contains every X coordinate where the line that we're drawing
+              # crosses the border of the shape we need to draw. In cases like a triangle, there
+              # will only be 2 intersections and we can just draw the line between them. But for
+              # more complex shapes where there e.g. a bunch of vertical spikes, we will have an
+              # (always evenly sized) array that we will need to sort and then iterate over
+              # 2 at a time, drawing lines between each slice of 2.
+              intersections.sort! if intersections.size > 2
+
+              i = 0
+              while i < intersections.length - 1 do
+                args.render_target(target).lines << {
+                  x: intersections[i], y: sprite_y,
+                  x2: intersections[i + 1], y2: sprite_y,
+                  **color.to_h, a: color.a * 0.7
+                }
+                i += 2
+              end
+            end
+
+            # Draw the outline connecting each point
+            object.points.each_with_index do |point, index|
+              next_point = object.points[(index + 1) % object.points.length]
+
+              args.render_target(target).lines << {
+                x: offset.x + point.x, y: offset.y + point.y,
+                x2: offset.x + next_point.x, y2: offset.y + next_point.y,
+                **color.to_h
+              }
+            end
+
+            args.state.polygon_cached[target] = true
           end
+
+          width = max_x - min_x + 2
+          height = max_y - min_y + 2
+
+          outputs_layer << {
+            x: object.x - (object.points[0].x - min_x) - 1,
+            y: object.y - (object.points[0].y - min_y) - 1,
+            w: width, h: height,
+            path: target,
+            source_x: 0, source_y: 0,
+            source_w: width, source_h: height,
+            **color.to_h
+          }
         when :point
           size = 10
           outputs_layer << {

--- a/lib/tiled/tiled_object.rb
+++ b/lib/tiled/tiled_object.rb
@@ -19,13 +19,21 @@ module Tiled
             pt.split(',').map(&:to_f).tap { |coords| coords.y *= -1 }
           end
         )
-      end
 
-      # Convert these attributes to floats
-      %w[width height x].each { |attr| attributes.add(attr => attrs[attr].to_f) }
+        x_values = points.map(&:x)
+        y_values = points.map(&:y)
+
+        attributes.add({
+          width: x_values.max - x_values.min + 2,
+          height: y_values.max - y_values.min + 2
+        })
+      else
+        %w[width height].each { |attr| attributes.add(attr => attrs[attr].to_f) }
+      end
 
       # Flip Y-axis
       attributes.add('y' => (map.height.to_f * map.tileheight.to_f) - (attrs['y'].to_f + height))
+      attributes.add('x' => attrs['x'].to_f)
     end
   end
 end


### PR DESCRIPTION
I overcame the performance issue discussed [here](https://github.com/wildfiler/drtiled/pull/15#issuecomment-1528691754) by rendering them to sprites, caching those and then "simply" rendering those in the right position. This turned out to be non-trivial as the offsets all needed to be adjusted since you can't render a target around 0, 0. Here are some bloopers for your amusement. :laughing: 

![2023-04-29-021622_1932x1081_scrot](https://user-images.githubusercontent.com/1045694/235343834-ac247fc0-1e48-4d10-9874-a4fa9a24a726.png)
![2023-04-30-010128_1893x1065_scrot](https://user-images.githubusercontent.com/1045694/235343851-6aeb6cb8-92e3-409d-a04d-d72e1a4955ff.png)

I also discovered that my algorithm was a bit naive and did this shit if there was any vertical deflection in the polygon:
![2023-04-30-012502_1893x1063_scrot](https://user-images.githubusercontent.com/1045694/235343856-e2466338-4585-47ca-b85d-e27453636d7a.png)

That turned out to be easy to address. Anyway, everything is very well-behaved and performant now. :beers: 
![2023-04-30-034223_1887x1059_scrot](https://user-images.githubusercontent.com/1045694/235343953-575b12f9-a0f0-4975-8563-06ffeb172e9d.png)

This PR also fixes a bug where the width and height of polygons were being initialized to `0.0`.