### PR TITLE
Add tile object support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ end
 
 object_layer.render(args) # Renders to args.outputs.primitives
 collision_layer.render(args, :debug) # Renders to args.outputs.debug
+object_layer.render(args, args.render_target(:foo)) # You may also pass in a GTK::Outputs
 ```
 
 `#type` will give you one of the following:

--- a/README.md
+++ b/README.md
@@ -108,26 +108,26 @@ Object layers can be found using `Map#layers` as well.
 
 ```ruby
 object_layer = map.layers['object'] # Get it the same as any other layer
-object_layer.objects.each do |object|
-  next unless object.shape == :rectangle
 
-  if player_primitive.intersect_rect?([object.x, object.y, object.width, object.height])
+collision_layer = map.layers['collision']
+collision_layer.objects.each do |hitbox|
+  if player_primitive.intersect_rect?([hitbox.x, hitbox.y, hitbox.width, hitbox.height])
     # handle collision...
   end
 end
 
-# Renders the objects to args.outputs.debug as long as the
-# layer is set to visible in Tiled
-object_layer.render_debug(args, args.outputs.debug)
+object_layer.render(args) # Renders to args.outputs.primitives
+collision_layer.render(args, :debug) # Renders to args.outputs.debug
 ```
 
-`#shape` will give you one of the following:
+`#type` will give you one of the following:
 
  * `:rectangle`: The object has `x`, `y`, `width`, and `height` attributes
  * `:ellipse`: Same attributes as rectangle
  * `:polygon`: Has `x`, `y`, and a `points` attribute containing an array of
                points relative to the [x, y] point
  * `:point`: Has `x` and `y` attributes
+ * `:tile`: Has `gid`, `x`, `y`, `width`, and `height` attributes
 
 ## Running samples
 

--- a/lib/tiled/layer.rb
+++ b/lib/tiled/layer.rb
@@ -79,7 +79,7 @@ module Tiled
           else
             raise_unsupported_render_order!
           end
-          sprite_class.from_tiled(x * width, sprite_y, tile)
+          sprite_class.from_tiled(tile, x: x * width, y: sprite_y)
         end.compact
       end
     end

--- a/lib/tiled/object_layer.rb
+++ b/lib/tiled/object_layer.rb
@@ -38,7 +38,7 @@ module Tiled
     def render(args, target=:primitives)
       return unless visible?
 
-      outputs_layer = args.outputs.send(target)
+      outputs_layer = target.is_a?(Symbol) ? args.outputs.send(target) : target
 
       # Resolution of circle
       radius = 300
@@ -60,9 +60,10 @@ module Tiled
       end
 
       objects.each do |object|
-        case object.type
+        case object.object_type
         when :tile
-          outputs_layer << Sprite.from_tiled(object.x, object.y, map.find_tile(object.gid),
+          outputs_layer << Sprite.from_tiled(map.find_tile(object.gid),
+                                             x: object.x, y: object.y,
                                              w: object.width, h: object.height)
         when :rectangle
           border = {

--- a/lib/tiled/object_layer.rb
+++ b/lib/tiled/object_layer.rb
@@ -33,10 +33,12 @@ module Tiled
     end
 
     # Renders the objects to the `outputs_layer`.
-    # @param args `args` from `tick` method
-    # @param output_layer one of `args.outputs`, works with `primitives` and `debug`
-    def render_debug(args, outputs_layer)
+    # @param args [GTK::Args] `args` from `tick` method
+    # @param target [Symbol] the output target, either :primitives or :debug
+    def render(args, target=:primitives)
       return unless visible?
+
+      outputs_layer = args.outputs.send(target)
 
       # Resolution of circle
       radius = 300
@@ -58,7 +60,10 @@ module Tiled
       end
 
       objects.each do |object|
-        case object.shape
+        case object.type
+        when :tile
+          outputs_layer << Sprite.from_tiled(object.x, object.y, map.find_tile(object.gid),
+                                             w: object.width, h: object.height)
         when :rectangle
           border = {
             primitive_marker: :border,

--- a/lib/tiled/sprite.rb
+++ b/lib/tiled/sprite.rb
@@ -18,7 +18,7 @@ module Tiled
     end
 
     # @return [Tiled::Sprite] return sprite object from `Tiled::Tile` object.
-    def self.from_tiled(x, y, tile, w: nil, h: nil)
+    def self.from_tiled(tile, x:, y:, w: nil, h: nil)
       new(
         path: tile.path,
         x: x.to_i,

--- a/lib/tiled/sprite.rb
+++ b/lib/tiled/sprite.rb
@@ -18,13 +18,13 @@ module Tiled
     end
 
     # @return [Tiled::Sprite] return sprite object from `Tiled::Tile` object.
-    def self.from_tiled(x, y, tile)
+    def self.from_tiled(x, y, tile, w: nil, h: nil)
       new(
         path: tile.path,
         x: x.to_i,
         y: y.to_i,
-        w: tile.tile_w.to_i,
-        h: tile.tile_h.to_i,
+        w: w || tile.tile_w.to_i,
+        h: h || tile.tile_h.to_i,
         tile_x: tile.tile_x.to_i,
         tile_y: tile.tile_y.to_i,
         tile_w: tile.tile_w.to_i,

--- a/lib/tiled/tiled_object.rb
+++ b/lib/tiled/tiled_object.rb
@@ -10,7 +10,7 @@ module Tiled
       @map = map
       attributes.add(id: attrs['id'], gid: attrs['gid']&.to_i)
 
-      attributes.add(type: children.any? ? children.first[:name].to_sym : gid ? :tile : :rectangle)
+      attributes.add(object_type: detect_type(attrs, children))
 
       if type == :polygon
         attributes.add(
@@ -35,8 +35,20 @@ module Tiled
 
       # Flip Y-axis
       attributes.add('y' => (map.height.to_f * map.tileheight.to_f) -
-                            (attrs['y'].to_f + (type == :tile ? 0 : height)))
+                            (attrs['y'].to_f + (object_type == :tile ? 0 : height)))
       attributes.add('x' => attrs['x'].to_f)
+    end
+
+    private
+
+    def detect_type(attrs, children)
+      if children.any?
+        children.first[:name].to_sym
+      elsif attrs['gid']
+        :tile
+      else
+        :rectangle
+      end
     end
   end
 end

--- a/lib/tiled/tiled_object.rb
+++ b/lib/tiled/tiled_object.rb
@@ -4,13 +4,15 @@ module Tiled
     include Tiled::WithAttributes
 
     attr_reader :map
-    attributes :id, :x, :y, :width, :height, :shape, :points
+    attributes :id, :gid, :x, :y, :width, :height, :type, :points
 
     def initialize(map, attrs, children)
       @map = map
-      attributes.add(id: attrs['id'], shape: children.any? ? children.first[:name].to_sym : :rectangle)
+      attributes.add(id: attrs['id'], gid: attrs['gid']&.to_i)
 
-      if shape == :polygon
+      attributes.add(type: children.any? ? children.first[:name].to_sym : gid ? :tile : :rectangle)
+
+      if type == :polygon
         attributes.add(
           # Input format for the points is: "0,0 64,-64 64,0"
           # This is turned into: [[0, 0], [64, 64], [64, 0]]
@@ -32,7 +34,8 @@ module Tiled
       end
 
       # Flip Y-axis
-      attributes.add('y' => (map.height.to_f * map.tileheight.to_f) - (attrs['y'].to_f + height))
+      attributes.add('y' => (map.height.to_f * map.tileheight.to_f) -
+                            (attrs['y'].to_f + (type == :tile ? 0 : height)))
       attributes.add('x' => attrs['x'].to_f)
     end
   end

--- a/lib/tiled/tileset.rb
+++ b/lib/tiled/tileset.rb
@@ -86,7 +86,7 @@ module Tiled
     #
     # @return <Tiled::Sprite> sprite object.
     def sprite_at(x, y, id)
-      @sprite_class.from_tiled(x, y, tiles[id])
+      @sprite_class.from_tiled(tiles[id], x: x, y: y)
     end
 
     [:tilewidth, :tileheight, :columns, :spacing, :margin, :firstgid, :tilecount].each do |name|


### PR DESCRIPTION
Since the scope of `ObjectLayer#render_debug` is no longer only for debugging, I have renamed it to `ObjectLayer#render`. I also tweaked its parameters so it's nicer to call and defaults to `args.outputs.primitives`.

The header of `Sprite::from_tiled` now takes optional width and height params:
```rb
def self.from_tiled(x, y, tile, w: nil, h: nil)
```
This way avoids breaking existing implementations, but it's a bit ugly. Assuming we're still in the "move fast and break shit" stage of development, we might consider putting the `tile` parameter first, so that x/y/w/h are right next to each other. Your call, this doesn't bother me *that* much.