### PR TITLE
Change offset and parallax attributes to tuples

### DIFF
--- a/lib/tiled/layer.rb
+++ b/lib/tiled/layer.rb
@@ -7,7 +7,7 @@ module Tiled
     RIGHT_UP = 'right-up'.freeze
 
     attr_reader :map, :data
-    attributes :id, :name, :x, :y, :width, :height, :opacity, :visible, :tintcolor, :offsetx, :offsety
+    attributes :id, :name, :x, :y, :width, :height, :opacity, :visible, :tintcolor, :offset, :parallax
 
     def initialize(map)
       @map = map
@@ -17,7 +17,13 @@ module Tiled
     # @param hash [Hash] hash loaded from xml file of map.
     # @return [Tiled::Layer] self
     def from_xml_hash(hash)
-      attributes.add(hash[:attributes])
+      raw_attributes = hash[:attributes]
+      raw_attributes['offset'] = [raw_attributes.delete('offsetx').to_f,
+                                 -raw_attributes.delete('offsety').to_f]
+      raw_attributes['parallax'] = [raw_attributes.delete('parallaxx')&.to_f || 1.0,
+                                    raw_attributes.delete('parallaxy')&.to_f || 1.0]
+
+      attributes.add(raw_attributes)
 
       hash[:children].each do |child|
         case child[:name]

--- a/lib/tiled/object_layer.rb
+++ b/lib/tiled/object_layer.rb
@@ -4,7 +4,7 @@ module Tiled
     include Tiled::WithAttributes
 
     attr_reader :map, :objects
-    attributes :id, :color, :r, :g, :b, :visible
+    attributes :id, :color, :r, :g, :b, :visible, :offset, :parallax
 
     def initialize(map)
       @map = map
@@ -18,6 +18,10 @@ module Tiled
       raw_attributes = hash[:attributes]
       raw_attributes['visible'] = raw_attributes['visible'] != '0'
       raw_attributes['color'] = Color.from_tiled_rgba(raw_attributes['color'])
+      raw_attributes['offset'] = [raw_attributes.delete('offsetx').to_f,
+                                 -raw_attributes.delete('offsety').to_f]
+      raw_attributes['parallax'] = [raw_attributes.delete('parallaxx')&.to_f || 1.0,
+                                    raw_attributes.delete('parallaxy')&.to_f || 1.0]
 
       attributes.add(raw_attributes)
 


### PR DESCRIPTION
I think this cleans up the interface quite a bit, and allows easier passing into functions that take [X, Y] tuples. Do you agree?