### PR TITLE
Convert attributes to the correct types when initializing objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ end
 
 object_layer.render(args) # Renders to args.outputs.primitives
 collision_layer.render(args, :debug) # Renders to args.outputs.debug
-object_layer.render(args, args.render_target(:foo)) # You may also pass in a GTK::Outputs
+object_layer.render(args, args.render_target(:foo).primitives) # You may also pass in a GTK::OutputsArray
 ```
 
 `#type` will give you one of the following:

--- a/lib/tiled/attributes.rb
+++ b/lib/tiled/attributes.rb
@@ -3,8 +3,12 @@ module Tiled
     include Tiled::Serializable
 
     def initialize(hash)
+      add hash
+    end
+
+    def add(hash)
       hash.each do |key, value|
-        instance_variable_set(:"@#{key}", value)
+        instance_variable_set(:"@#{key}", convert_type(value))
 
         instance_eval(<<-CODE)
           undef :#{key} if respond_to? :#{key}
@@ -15,16 +19,29 @@ module Tiled
       end
     end
 
-    def add(hash)
-      hash.each do |key, value|
-        instance_variable_set(:"@#{key}", value)
-        instance_eval(<<-CODE)
-          undef :#{key} if respond_to? :#{key}
-          def #{key}
-            @#{key}
-          end
-        CODE
-      end
+    private
+
+    # If `obj` is a String containing a valid Integer or Float, it will be
+    # converted to one of those types; otherwise, it well be left alone.
+    def convert_type(obj)
+      if obj.is_a?(String)
+        decimal_split = obj.split('.')
+        as_int = obj.to_i
+
+        if decimal_split.size == 2 && decimal_split.all? { |s| check_int s }
+          obj.to_f
+        elsif as_int.to_s == obj
+          as_int
+        end
+      end || obj
+    end
+
+    # @return [Boolean] whether or not `str` is a valid Integer
+    def check_int(str)
+      # Allow leading zeros by removing them from the string before comparison
+      chars = str.chars
+      chars.shift while chars.first == '0'
+      str.to_i.to_s == chars.join
     end
   end
 end

--- a/lib/tiled/layer.rb
+++ b/lib/tiled/layer.rb
@@ -18,6 +18,7 @@ module Tiled
     # @return [Tiled::Layer] self
     def from_xml_hash(hash)
       raw_attributes = hash[:attributes]
+      raw_attributes['visible'] = raw_attributes['visible'] != '0'
       raw_attributes['offset'] = [raw_attributes.delete('offsetx').to_f,
                                  -raw_attributes.delete('offsety').to_f]
       raw_attributes['parallax'] = [raw_attributes.delete('parallaxx')&.to_f || 1.0,
@@ -51,7 +52,7 @@ module Tiled
     # Get tile by x, y coordinates (0, 0 is based on tile render order)
     # @return [Tiled::Tile, nil] tile at x, y coordinate on this layer or `nil`
     def tile_at(x, y)
-      tiles[render_order == RIGHT_DOWN ? y : map.attributes.height.to_i - 1 - y][x]
+      tiles[render_order == RIGHT_DOWN ? y : map.attributes.height - 1 - y][x]
     end
 
     # Method to get array of visible and renderable sprites from layer.
@@ -69,9 +70,9 @@ module Tiled
       return @sprites if @sprites
 
       sprite_class = map.sprite_class
-      width = map.attributes.tilewidth.to_i
-      height = map.attributes.tileheight.to_i
-      map_height = map.attributes.height.to_i
+      width = map.attributes.tilewidth
+      height = map.attributes.tileheight
+      map_height = map.attributes.height
 
       @sprites = tile_rows.flat_map.with_index do |row, y|
         row.map.with_index do |tile, x|
@@ -94,10 +95,9 @@ module Tiled
       @properties ||= Properties.new(self)
     end
 
-    # Return `attributes.visible` converted to boolean
-    # @return [Boolean]
+    # @return [Boolean] whether or not the layer is visible
     def visible?
-      visible != '0'
+      visible
     end
 
     def exclude_from_serialize

--- a/lib/tiled/object_layer.rb
+++ b/lib/tiled/object_layer.rb
@@ -4,7 +4,7 @@ module Tiled
     include Tiled::WithAttributes
 
     attr_reader :map, :objects
-    attributes :id, :color, :r, :g, :b, :visible, :offset, :parallax
+    attributes :id, :color, :visible, :offset, :parallax
 
     def initialize(map)
       @map = map

--- a/lib/tiled/sprite.rb
+++ b/lib/tiled/sprite.rb
@@ -21,14 +21,14 @@ module Tiled
     def self.from_tiled(tile, x:, y:, w: nil, h: nil)
       new(
         path: tile.path,
-        x: x.to_i,
-        y: y.to_i,
-        w: w || tile.tile_w.to_i,
-        h: h || tile.tile_h.to_i,
-        tile_x: tile.tile_x.to_i,
-        tile_y: tile.tile_y.to_i,
-        tile_w: tile.tile_w.to_i,
-        tile_h: tile.tile_h.to_i,
+        x: x,
+        y: y,
+        w: w || tile.tile_w,
+        h: h || tile.tile_h,
+        tile_x: tile.tile_x,
+        tile_y: tile.tile_y,
+        tile_w: tile.tile_w,
+        tile_h: tile.tile_h,
       )
     end
   end

--- a/lib/tiled/tiled_object.rb
+++ b/lib/tiled/tiled_object.rb
@@ -12,7 +12,7 @@ module Tiled
 
       attributes.add(object_type: detect_type(attrs, children))
 
-      if type == :polygon
+      if object_type == :polygon
         attributes.add(
           # Input format for the points is: "0,0 64,-64 64,0"
           # This is turned into: [[0, 0], [64, 64], [64, 0]]
@@ -30,13 +30,21 @@ module Tiled
           height: y_values.max - y_values.min + 2
         })
       else
-        %w[width height].each { |attr| attributes.add(attr => attrs[attr].to_f) }
+        %w[width height].each { |attr| attributes.add(attr => attrs[attr]) }
       end
 
       # Flip Y-axis
-      attributes.add('y' => (map.height.to_f * map.tileheight.to_f) -
+      attributes.add('y' => (map.height * map.tileheight) -
                             (attrs['y'].to_f + (object_type == :tile ? 0 : height)))
-      attributes.add('x' => attrs['x'].to_f)
+      attributes.add('x' => attrs['x'])
+    end
+
+    [:width, :height].each do |name|
+      define_method name do
+        if attributes.respond_to? name
+          attributes.send(name)
+        end || 0
+      end
     end
 
     private

--- a/lib/tiled/tileset.rb
+++ b/lib/tiled/tileset.rb
@@ -92,10 +92,8 @@ module Tiled
     [:tilewidth, :tileheight, :columns, :spacing, :margin, :firstgid, :tilecount].each do |name|
       define_method name do
         if attributes.respond_to? name
-          attributes.send(name).to_i
-        else
-          0
-        end
+          attributes.send(name)
+        end || 0
       end
     end
 


### PR DESCRIPTION
Currently, all attributes are `String`s, doing these conversions at runtime is annoying and inefficient.

This has conflicts with #20 and #21, I recommend you take a look at those first and then I'll be around to rebase this and test that everything is still in working order.