### PR TITLE
Custom properties

### DIFF
--- a/lib/tiled/map.rb
+++ b/lib/tiled/map.rb
@@ -1,5 +1,4 @@
 module Tiled
-
   class Map
     include Tiled::Serializable
     include Tiled::WithAttributes
@@ -19,6 +18,9 @@ module Tiled
       xml = $gtk.parse_xml_file(@path)
       @map = xml[:children].first
       attributes.add(@map[:attributes])
+
+      custom_properties = nil
+
       map[:children].each do |child|
         case child[:name]
         when 'layer'
@@ -30,13 +32,16 @@ module Tiled
           objectlayer.from_xml_hash(child)
           layers.add objectlayer
         when 'properties'
-          properties.from_xml_hash(child[:children])
+          custom_properties = child[:children]
         when 'tileset'
           tileset = Tileset.new(self)
           tileset.from_xml_hash(child)
           tilesets << tileset
         end
       end
+
+      # This is done last so that it can parse the object properties
+      properties.from_xml_hash(custom_properties) if custom_properties
     end
 
     def layers

--- a/lib/tiled/object_layer.rb
+++ b/lib/tiled/object_layer.rb
@@ -25,8 +25,13 @@ module Tiled
 
       attributes.add(raw_attributes)
 
-      @objects = hash[:children].map do |child|
-        TiledObject.new(map, child[:attributes], child[:children])
+      hash[:children].each do |child|
+        case child[:name]
+        when 'properties'
+          properties.from_xml_hash(child[:children])
+        when 'object'
+          @objects << TiledObject.new(map, child[:attributes], child[:children])
+        end
       end
 
       self
@@ -34,6 +39,15 @@ module Tiled
 
     def [](id)
       objects.find { |o| o.id == id }
+    end
+
+    def properties
+      @properties ||= Properties.new(self)
+    end
+
+    # @return [Boolean] whether or not the layer is visible
+    def visible?
+      visible
     end
 
     def sprites
@@ -190,11 +204,6 @@ module Tiled
           }
         end
       end
-    end
-
-    # @return [Boolean] whether or not the layer is visible
-    def visible?
-      visible
     end
   end
 end

--- a/lib/tiled/object_layer.rb
+++ b/lib/tiled/object_layer.rb
@@ -32,6 +32,10 @@ module Tiled
       self
     end
 
+    def [](id)
+      objects.find { |o| o.id == id }
+    end
+
     def sprites
       []
     end

--- a/lib/tiled/properties.rb
+++ b/lib/tiled/properties.rb
@@ -20,10 +20,10 @@ module Tiled
     # @param value [Integer, Float, Boolean, String] value of added property
     # @return [Tiled::Properties] self
     def add(name, type = 'string', value)
+      name = name.downcase.gsub(' ', '_')
+
       instance_variable_set("@#{name}", value)
-      instance_variable_set("@#{name}_type", type)
       define_singleton_method(name) { instance_variable_get(:"@#{name}") }
-      define_singleton_method("#{name}_type") { instance_variable_get(:"@#{name}_type") }
       define_singleton_method("#{name}?") { !!instance_variable_get(:"@#{name}") } if type == 'bool'
 
       self
@@ -59,7 +59,12 @@ module Tiled
       when 'color'
         Color.from_tiled_rgba(raw_value)
       when 'object'
-        raw_value.to_i
+        @map.layers.find do |layer|
+          if layer.is_a?(ObjectLayer)
+            object = layer[raw_value.to_i]
+            break object if object
+          end
+        end
       when 'string'
         if raw_value
           raw_value

--- a/lib/tiled/properties.rb
+++ b/lib/tiled/properties.rb
@@ -46,6 +46,11 @@ module Tiled
       self
     end
 
+    # Finds a property by name, or returns nil.
+    def [](property)
+      respond_to?(property) ? instance_variable_get(:"@#{property}") : nil
+    end
+
     private
 
     def convert_value(children, raw_value, type)

--- a/lib/tiled/properties.rb
+++ b/lib/tiled/properties.rb
@@ -23,7 +23,9 @@ module Tiled
       name = name.downcase.gsub(' ', '_')
 
       instance_variable_set("@#{name}", value)
+      instance_variable_set("@#{name}_type", type)
       define_singleton_method(name) { instance_variable_get(:"@#{name}") }
+      define_singleton_method("#{name}_type") { instance_variable_get(:"@#{name}_type") }
       define_singleton_method("#{name}?") { !!instance_variable_get(:"@#{name}") } if type == 'bool'
 
       self

--- a/lib/tiled/tiled_object.rb
+++ b/lib/tiled/tiled_object.rb
@@ -52,7 +52,7 @@ module Tiled
     end
 
     def properties
-      @properties ||= Properties.new(self)
+      @properties ||= Properties.new(map)
     end
 
     private

--- a/lib/tiled/tiled_object.rb
+++ b/lib/tiled/tiled_object.rb
@@ -4,7 +4,7 @@ module Tiled
     include Tiled::WithAttributes
 
     attr_reader :map
-    attributes :id, :gid, :x, :y, :width, :height, :type, :points
+    attributes :id, :gid, :x, :y, :width, :height, :object_type, :points
 
     def initialize(map, attrs, children)
       @map = map

--- a/lib/tiled/tiled_object.rb
+++ b/lib/tiled/tiled_object.rb
@@ -10,6 +10,10 @@ module Tiled
       @map = map
       attributes.add(id: attrs['id'], gid: attrs['gid']&.to_i)
 
+      if (props_index = children.find_index { |child| child[:name] == 'properties' })
+        properties.from_xml_hash(children.delete_at(props_index)[:children])
+      end
+
       attributes.add(object_type: detect_type(attrs, children))
 
       if object_type == :polygon
@@ -45,6 +49,10 @@ module Tiled
           attributes.send(name)
         end || 0
       end
+    end
+
+    def properties
+      @properties ||= Properties.new(self)
     end
 
     private


### PR DESCRIPTION
This PR accomplises the following:

 * Object properties are now loaded as `TiledObject`s.
 * Property names are now converted to snake case (previously, spaces in the property name would cause a crash).
 * ~~Removed the `#xxx_type` singleton method since the types are now all properly set anyway; you can just use `Object#class` or `Object#is_a?`.~~
 * Added custom property support for `TiledObject` and `ObjectLayer`s.
 * Added `Properties#[]` for ease of finding configuration values without needing to check the `#respond_to?` all the time. We *could* do this as a `method_missing`, but this is probably better form.