### PR TITLE
Use `w` and `h` params in `AnimatedSprite::from_tiled`

### DIFF
--- a/lib/tiled/animated_sprite.rb
+++ b/lib/tiled/animated_sprite.rb
@@ -8,12 +8,12 @@ module Tiled
     # @return [Tiled::AnimatedSprite] return sprite object from `Tiled::Tile` object.
     def self.from_tiled(tile, x:, y:, w: nil, h: nil)
       new(
-        x: x.to_i,
-        y: y.to_i,
-        w: tile.tile_w.to_i,
-        h: tile.tile_h.to_i,
-        tile_w: tile.tile_w.to_i,
-        tile_h: tile.tile_h.to_i,
+        x: x,
+        y: y,
+        w: w || tile.tile_w,
+        h: h || tile.tile_h,
+        tile_w: tile.tile_w,
+        tile_h: tile.tile_h,
         animation: tile.animation,
       )
     end


### PR DESCRIPTION
Also, were the `to_i` conversions necessary? These should always be floats, unless I'm missing something. In the (I think impossible?) case of nils here DR converts them to zero anyway, so it's doing the same thing under the hood (and, possibly more quickly?). If I'm wrong and we do need these conversions, we should do them in `Sprite` too for consistency (I had removed them in f804b54).

:fire: feature BTW.