### PR TITLE
Add `pixelwidth` and `pixelheight` Map attributes

### DIFF
--- a/lib/tiled/map.rb
+++ b/lib/tiled/map.rb
@@ -76,5 +76,13 @@ module Tiled
     def exclude_from_serialize
       super + %w[tiles_cache tilesets layers]
     end
+
+    def pixelwidth
+      width * tilewidth
+    end
+
+    def pixelheight
+      height * tileheight
+    end
   end
 end

--- a/lib/tiled/tiled_object.rb
+++ b/lib/tiled/tiled_object.rb
@@ -38,9 +38,10 @@ module Tiled
       end
 
       # Flip Y-axis
-      attributes.add('y' => (map.height * map.tileheight) -
-                            (attrs['y'].to_f + (object_type == :tile ? 0 : height)))
-      attributes.add('x' => attrs['x'])
+      attributes.add(
+        'y' => map.pixelheight - (attrs['y'].to_f + (object_type == :tile ? 0 : height)),
+        'x' => attrs['x']
+      )
     end
 
     [:width, :height].each do |name|


### PR DESCRIPTION
This is a useful attribute. We could do this as a method, but calculating on load saves cycles. I can change it if you'd like.