### PR TITLE
Decouple `Layer#tile_at` from render order

### DIFF
--- a/lib/tiled/layer.rb
+++ b/lib/tiled/layer.rb
@@ -49,10 +49,10 @@ module Tiled
       end
     end
 
-    # Get tile by x, y coordinates (0, 0 is based on tile render order)
+    # Get tile by x, y coordinates
     # @return [Tiled::Tile, nil] tile at x, y coordinate on this layer or `nil`
     def tile_at(x, y)
-      tiles[render_order == RIGHT_DOWN ? y : map.attributes.height - 1 - y][x]
+      tiles[y][x]
     end
 
     # Method to get array of visible and renderable sprites from layer.


### PR DESCRIPTION
Thinking more on it, it doesn't make sense to use the render order here; that's not what it's for. I for one can't imagine a scenario where a user would prefer to use an Y-axis opposite the one that the game engine uses, but if it should be supported, it should be as a separate option. WDYT?