### PR TITLE
Add reflection/rotation support

### DIFF
--- a/lib/tiled/animated_sprite.rb
+++ b/lib/tiled/animated_sprite.rb
@@ -8,13 +8,19 @@ module Tiled
     # @return [Tiled::AnimatedSprite] return sprite object from `Tiled::Tile` object.
     def self.from_tiled(tile, x:, y:, w: nil, h: nil)
       new(
+        path: tile.path,
         x: x,
         y: y,
         w: w || tile.tile_w,
         h: h || tile.tile_h,
+        tile_x: tile.tile_x,
+        tile_y: tile.tile_y,
         tile_w: tile.tile_w,
         tile_h: tile.tile_h,
         animation: tile.animation,
+        flip_horizontally: tile.flip_horizontally?,
+        flip_vertically: tile.flip_vertically?,
+        angle: tile.angle
       )
     end
 

--- a/lib/tiled/sprite.rb
+++ b/lib/tiled/sprite.rb
@@ -29,6 +29,9 @@ module Tiled
         tile_y: tile.tile_y,
         tile_w: tile.tile_w,
         tile_h: tile.tile_h,
+        flip_horizontally: tile.flip_horizontally?,
+        flip_vertically: tile.flip_vertically?,
+        angle: tile.angle
       )
     end
   end

--- a/lib/tiled/tile.rb
+++ b/lib/tiled/tile.rb
@@ -3,11 +3,15 @@ module Tiled
     include Tiled::Serializable
     include Tiled::WithAttributes
 
-    attr_reader :tileset, :path, :tile_w, :tile_h, :tile_x, :tile_y, :animation
+    attr_reader :tileset, :path, :tile_w, :tile_h, :tile_x, :tile_y, :angle, :animation
     attributes :id, :type, :terrain, :probability
 
     def initialize(tileset)
       @tileset = tileset
+
+      @flipped_horizontally = false
+      @flipped_vertically = false
+      @angle = 0
     end
 
     # TODO: Add terrain and animation support
@@ -56,6 +60,26 @@ module Tiled
       @animated ||= !animation.nil?
     end
 
+    def flip!(direction)
+      case direction
+      when :horizontally
+        @flipped_horizontally = !@flipped_horizontally
+      when :vertically
+        @flipped_vertically = !@flipped_vertically
+      when :diagonally
+        flip! :vertically
+        @angle += 90
+      end
+    end
+
+    def flip_horizontally?
+      @flipped_horizontally
+    end
+
+    def flip_vertically?
+      @flipped_vertically
+    end
+
     private
 
     def parse_image(child)
@@ -66,7 +90,7 @@ module Tiled
 
     def init_from_tileset
       @path = tileset.image.path
-      @tile_x, @tile_y, @tile_w, @tile_h = tileset.id_to_xywh(id.to_i)
+      @tile_x, @tile_y, @tile_w, @tile_h = tileset.id_to_xywh(id)
     end
   end
 end

--- a/lib/tiled/tileset.rb
+++ b/lib/tiled/tileset.rb
@@ -73,8 +73,8 @@ module Tiled
       @tiles ||= []
     end
 
-    def find(gid)
-      id = gid - firstgid
+    def find(cleared_gid)
+      id = cleared_gid - firstgid
       tiles[id]
     end
 


### PR DESCRIPTION
I would have loved to somehow set this in the `Tile` constructor (avoiding needing to `#dup` every flipped tile), but it seems (correct me if I'm wrong) the GID never makes it that far, and it'd require a fair bit of restructuring to get it there.