### PR TITLE
Inherit `Layers` from `Array`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The tilesets and spritesheets used in map should be placed inside your game dir,
 
 ```ruby
 ground_layer = map.layers['ground'] # Get layer by name
-collisions_layer = map.layers['collisions']
-layer_5 = map.layers.at(5) # Get layer by index
+collisions_layer = map.layers[:collisions] # Symbols work too
+layer_5 = map.layers[5] # Get layer by index
 
 map.layers.select(&:visible?) # Get visible layers
 ```

--- a/lib/tiled/layers.rb
+++ b/lib/tiled/layers.rb
@@ -1,47 +1,17 @@
 module Tiled
-  class Layers
-    # Collection for layers storage. Just an array with indexing by name.
-
-    include Enumerable
-
-    def initialize
-      @layers = []
-    end
-
+  # Collection for layers storage. Just an array with indexing by name.
+  class Layers < Array
     # Access layer by its name
     # @param name [String] name of layer
     # @return [Tiled::Layer, nil] Layer or nil if layer with this name doesn't exists.
     def [](name)
-      @layers_indexes ||= {}
-      @layers_indexes[name] ||= @layers.detect { |layer| layer.name == name}
+      if [String, Symbol].any? { |cls| name.is_a? cls }
+        detect { |layer| layer.name == name.to_s }
+      else
+        super(name)
+      end
     end
 
-    # Access layer by its index
-    # @param index [Integer] layer index
-    # @return [Tiled::Layer, nil]
-    def at(index)
-      @layers[index]
-    end
-
-    # Add layer
-    # @param layer [Tiled::Layer] add layer to collection
-    # @return [Tiled::Layers] self
-    def add(layer)
-      @layers << layer
-      self
-    end
-
-    def last
-      @layers.last
-    end
-
-    # Delegate each to internal array to implement Enumerable interface.
-    def each(&block)
-      @layers.each(&block)
-    end
-
-    def empty?
-      @layers.empty?
-    end
+    alias add <<
   end
 end

--- a/lib/tiled/tiled.rb
+++ b/lib/tiled/tiled.rb
@@ -38,7 +38,7 @@ module Tiled
   class Color; end
   class Image; end
   class Layer; end
-  class Layers; end
+  class Layers < Array; end
   class LayerData; end
   class Map; end
   class MapObject; end


### PR DESCRIPTION
Needed `#size`, and realized this class basically encapsulates a lone `Array` anyway. Only caveat to this is that we cannot cache the layers by name anymore, because `Array` is implemented as a C struct. I tried to benchmark the performance impact of this, but ~~it was so neglibible that the variance from run to run was greater than the difference between caching and not caching~~ EDIT: never mind. I'm a dumbass. Still, we can do 140k `#detect`s per frame on a map with 10 layers ;)