### PR TITLE
Map object by name

### DIFF
--- a/lib/tiled/map.rb
+++ b/lib/tiled/map.rb
@@ -89,6 +89,28 @@ module Tiled
       return height * tileheight
     end
 
+    #gets the first object layer with the passed name of `layer_name`
+    #then looks in that layer for the first object that has the name `object_name`
+    #then returns that object
+    def object_by_name(layer_name, object_name)
+      
+      named_layer = @object_groups.reject do | layer |
+        layer.name != layer_name
+      end.first
+
+      raise ObjectLayerNotFound, "The object layer \"#{layer_name}\" was not found in map \"#{@path}\"" if named_layer.nil?
+      
+      the_object = named_layer.objects.reject do | object |
+        object.name != object_name
+      end
+
+      raise ObjectNameNotFound, "The object named \"#{object_name}\" was not found in object layer \"#{layer_name}\"" if the_object.empty?
+
+      #if we get multiple objects with the name passed, only return the first item.
+      the_object.first
+    end
+
+    
     private
 
     def cache_tile(gid)

--- a/lib/tiled/tiled.rb
+++ b/lib/tiled/tiled.rb
@@ -62,4 +62,8 @@ module Tiled
   class ParseError < Error; end
   class MapNotFound < Error; end
   class TilesetNotFound < Error; end
+  
+  #added the following exceptions, which are raised in the object_by_name of the Tiled::Map class
+  class ObjectLayerNotFound < Error; end
+  class ObjectNameNotFound < Error; end
 end


### PR DESCRIPTION
As discussed. Added a method to the map class that allows you to look up an object by name, given a specific name for a map/object layer.

If the object layer named can't be found, it will raise an `ObjectLayerNotFound` error. giving the name of the object layer passed and which map (via the path) couldn't find it.

if that doesn't fail, the method then checks for an object in the layer with the passed name. 

if the object can't be found, it will raise an `ObjectNameNotFound` error, giving the name of the object that couldn't be found on the passed layer name.