### PR TITLE
Add properties to image layer

### DIFF
--- a/lib/tiled/image_layer.rb
+++ b/lib/tiled/image_layer.rb
@@ -57,6 +57,10 @@ module Tiled
       []
     end
 
+    def properties
+      @properties ||= Properties.new(self)
+    end
+
     private
 
     def sprite(x_index = 0, y_index = 0)


### PR DESCRIPTION
The `properties` method is missing in `ImageLayer` causing an exception when an image layer has custom properties.

The first commit explicitly scopes the class in the `Tiled` module
The second commit add the propertied method, lifted verbatim from `ObjectLayer`